### PR TITLE
TEMP: prove the CI mypy gate FAILS on a real defect (C5)

### DIFF
--- a/src/swarm/tasks/blockers.py
+++ b/src/swarm/tasks/blockers.py
@@ -306,3 +306,8 @@ class BlockerStore:
                 exc_info=True,
             )
             return False
+
+
+def _c5_injected_type_error(x: int) -> str:
+    """DELIBERATE defect to prove the mypy gate can FAIL in CI (#1081 C5)."""
+    return x


### PR DESCRIPTION
Throwaway. Injects a deliberate type error into src/swarm/tasks/blockers.py — a module NOT on pyproject's mypy override list — to produce a CI-level record of the gate failing. Base is a feature branch, not main, so this also exercises the #1081 trigger fix. Deleted after measurement.