### PR TITLE
fix(pwa): stop re-registering kill-switch worker

### DIFF
--- a/src/swarm/web/templates/base.html
+++ b/src/swarm/web/templates/base.html
@@ -3528,7 +3528,13 @@
     {% block scripts %}{% endblock %}
     <script nonce="{{ csp_nonce }}">
     if ('serviceWorker' in navigator) {
-        {% if is_dev %}
+        // 2026.8.10.10 turned /sw.js into a kill switch: on activation it
+        // unregisters itself and navigates every client.  Registering that same
+        // worker here on every production load made the cleanup non-convergent:
+        // load -> register -> activate -> unregister+navigate -> load.  Edge's
+        // browser process reached 4 GB in under a minute with only Swarm open.
+        // Cleanup belongs in the page, and the kill-switch worker must never be
+        // recreated after it removes itself.
         navigator.serviceWorker.getRegistrations().then(function(registrations) {
             registrations.forEach(function(reg) { reg.unregister().catch(function() {}); });
         }).catch(function() {});
@@ -3539,9 +3545,6 @@
                 });
             }).catch(function() {});
         }
-        {% else %}
-        navigator.serviceWorker.register('/sw.js?v={{ build_sha or version }}', { updateViaCache: 'none' }).catch(function() {});
-        {% endif %}
     }
     </script>
 </body>

--- a/tests/test_sw_cache_leak.py
+++ b/tests/test_sw_cache_leak.py
@@ -24,6 +24,34 @@ from __future__ import annotations
 from pathlib import Path
 
 _SW = Path("src/swarm/web/static/sw.js").read_text(encoding="utf-8")
+_BASE = Path("src/swarm/web/templates/base.html").read_text(encoding="utf-8")
+
+
+def test_the_page_does_not_reregister_the_kill_switch_worker():
+    """The production page must not recreate the worker it is trying to remove.
+
+    2026.8.10.10 changed ``sw.js`` into a kill switch whose activate handler
+    unregisters itself and navigates every client.  ``base.html`` still registered
+    that file on every production page load, creating an unbounded browser-process
+    loop::
+
+        page load -> register -> activate -> unregister + navigate -> page load
+
+    Edge reached 4 GB private memory in under a minute with only Swarm open.  The
+    cleanup belongs in the page; registering an unregistering worker can never
+    converge.
+    """
+    assert "serviceWorker.register(" not in _BASE, (
+        "base.html recreates the service-worker kill switch on every load; its "
+        "activate-time navigation then reloads the page and starts the cycle again"
+    )
+
+
+def test_the_page_removes_existing_workers_and_swarm_caches():
+    """Removing registration must still clean up installs from older releases."""
+    assert "serviceWorker.getRegistrations()" in _BASE
+    assert "reg.unregister()" in _BASE
+    assert "caches.keys()" in _BASE and "caches.delete(" in _BASE
 
 
 def test_the_worker_unregisters_itself():


### PR DESCRIPTION
## What changed

- stop production pages from registering the service-worker kill switch on every load
- keep page-side cleanup for existing service-worker registrations and Swarm caches
- add regression coverage that prevents the registration loop from returning

## Root cause

Release `2026.8.10.10` changed `/sw.js` into a kill switch that unregisters itself and navigates every controlled client during activation. `base.html` still registered `/sw.js` on every production page load, creating a non-convergent cycle:

`load -> register -> activate -> unregister + navigate -> load`

In two clean Edge reproductions with only Swarm open, one Edge process reached 4,096 MB private memory within roughly a minute and total Edge memory reached 4.4-4.8 GB.

## Impact

The cleanup now converges: an existing worker is unregistered and old Swarm caches are deleted, but the page does not recreate the worker it just removed.

## Validation

- `34 passed, 11 deselected` across the relevant dashboard/PWA tests
- `ruff check src/ tests/` passed
- `git diff --check` passed
- native-Windows full-suite collection is not representative because the application imports Linux-only `fcntl`; GitHub Actions provides the authoritative Python 3.12/3.13 Linux matrix
